### PR TITLE
Reasonable disable_if default

### DIFF
--- a/lib/analytical.rb
+++ b/lib/analytical.rb
@@ -18,7 +18,12 @@ module Analytical
     File.open("#{Rails.root}/config/analytical.yml") do |f|
       file_options = YAML::load(ERB.new(f.read).result).symbolize_keys
       env = (Rails.env || :production).to_sym
-      file_options = file_options[env] if file_options.has_key?(env)
+      if file_options.has_key?(env)
+        file_options = file_options[env]
+      else
+        # If the current environment has no config, disable analytical
+        config_options[:disable_if] = Proc.new { true }
+      end
       file_options.each do |k, v|
         config_options[k.to_sym] = v.symbolize_keys
         config_options[:modules] << k.to_sym unless options && options[:modules]


### PR DESCRIPTION
As a default, this disables analytical if the YAML file has no key for the current environment. Currently, every environment expects to be configured and will cause javascript errors by including the scripts for modules. 

This can be done in with the current gem in the controller that adds analytical:

```
 analytical modules: [:google, :chartbeat], disable_if: Proc.new { !Rails.env.production? || !Rails.env.test? }
```

Seems like a nice addition if you agree.
